### PR TITLE
Design pilot: warmer, consistent tab headers across all five tabs

### DIFF
--- a/mobile-app/src/components/add-wine-panel.tsx
+++ b/mobile-app/src/components/add-wine-panel.tsx
@@ -6,7 +6,7 @@ import type { StorageSpaceDraft, WineDraft } from "../types/cellar-drafts";
 import type { WineRecord } from "../types/wine";
 import type { CatalogProps, TastingProps } from "../types/panel-prop-groups";
 import { AutocompleteInput, Expandable, LabeledInput, PanelHeader, SuggestionRow } from "./form-controls";
-import { colors } from "../styles/theme";
+import { colors, serifFont } from "../styles/theme";
 import type { styles as themeStyles } from "../styles/theme";
 import { WineCoreFields } from "./wine-core-fields";
 import { TastingFields } from "./tasting-fields";
@@ -23,7 +23,11 @@ export function AddWinePanel(props: AddWinePanelProps) {
 
   return (
     <View style={styles.panel}>
-      <PanelHeader title="Lägg till vin" rightLabel="Profil" onRightPress={props.onOpenProfile} />
+      <PanelHeader rightLabel="Profil" onRightPress={props.onOpenProfile} />
+      <View>
+        <Text style={titleStyles.title}>Lägg till vin</Text>
+        <Text style={titleStyles.sub}>Fyll i själv, eller skanna etiketten</Text>
+      </View>
       <SuggestionRow title="Läge" options={["Källare", "Vinprovning"]} selected={tastingMode ? "Vinprovning" : "Källare"} onSelect={(value) => onTastingModeChange(value === "Vinprovning")} />
       {tastingMode ? <Text style={styles.notesText}>Vinet sparas direkt i din historik — det läggs inte till i källaren.</Text> : null}
 
@@ -82,6 +86,11 @@ function SavedPrompt({ onGoToCellar, onAddMore }: { onGoToCellar?: () => void; o
     </View>
   );
 }
+
+const titleStyles = StyleSheet.create({
+  title: { fontFamily: serifFont, color: colors.text, fontSize: 32, fontWeight: "700", lineHeight: 34 },
+  sub: { color: colors.textSecondary, fontSize: 13, marginTop: 4 },
+});
 
 const savedStyles = StyleSheet.create({
   container: { alignItems: "center", gap: 8, paddingVertical: 20 },

--- a/mobile-app/src/components/cellar-list-header.tsx
+++ b/mobile-app/src/components/cellar-list-header.tsx
@@ -5,7 +5,8 @@ import type { FilterProps, StorageProps } from "../types/panel-prop-groups";
 import { Expandable, InsightCard, LabeledInput, LoadingInline, PanelHeader, StorageSpaceForm, SuggestionRow } from "./form-controls";
 import { BottleDoodle, SquigglyLine } from "./doodles";
 
-import { colors, type styles as themeStyles } from "../styles/theme";
+import { StyleSheet } from "react-native";
+import { colors, serifFont, type styles as themeStyles } from "../styles/theme";
 type SharedStyles = typeof themeStyles;
 
 export type CellarListHeaderProps = {
@@ -26,8 +27,8 @@ export type CellarListHeaderProps = {
 export function CellarListHeader(props: CellarListHeaderProps) {
   return (
     <View style={{ gap: 14, paddingBottom: 6 }}>
-      <PanelHeader title="Min källare" rightLabel="Profil" onRightPress={props.onSignOut} />
-      <StatsSummaryBar {...props} />
+      <PanelHeader rightLabel="Profil" onRightPress={props.onSignOut} />
+      <TitleAndStats {...props} />
       <CellarFilters {...props} />
       {props.loading ? <LoadingInline /> : null}
       <StorageSpaceForm
@@ -41,11 +42,15 @@ export function CellarListHeader(props: CellarListHeaderProps) {
   );
 }
 
-function StatsSummaryBar({ styles, statsExpanded, onToggleStats, summaryText, stats, onRefreshStats }: CellarListHeaderProps) {
+function TitleAndStats({ styles, statsExpanded, onToggleStats, summaryText, stats, onRefreshStats }: CellarListHeaderProps) {
   return (
     <>
-      <Pressable onPress={onToggleStats} style={({ pressed }) => [styles.statsSummaryBar, pressed && { opacity: 0.8 }]}>
-        <Text style={styles.statsSummaryText}>{summaryText}</Text>
+      <View>
+        <Text style={header.title}>Min källare</Text>
+        <Text style={header.sub}>{summaryText}</Text>
+      </View>
+      <Pressable onPress={onToggleStats} style={({ pressed }) => [header.toggleRow, pressed && { opacity: 0.7 }]}>
+        <Text style={header.toggleText}>{statsExpanded ? "Dölj statistik" : "Visa statistik"}</Text>
         <Text style={styles.sectionChevron}>{statsExpanded ? "▾" : "›"}</Text>
       </Pressable>
       <Expandable expanded={statsExpanded}>
@@ -64,6 +69,13 @@ function StatsSummaryBar({ styles, statsExpanded, onToggleStats, summaryText, st
     </>
   );
 }
+
+const header = StyleSheet.create({
+  title: { fontFamily: serifFont, color: colors.text, fontSize: 32, fontWeight: "700", lineHeight: 34 },
+  sub: { color: colors.textSecondary, fontSize: 13, marginTop: 4 },
+  toggleRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 4 },
+  toggleText: { color: colors.accent, fontSize: 13, fontWeight: "700" },
+});
 
 function CellarFilters({ styles, filter, storage }: CellarListHeaderProps) {
   const [filtersExpanded, setFiltersExpanded] = useState(false);

--- a/mobile-app/src/components/cellar-sections.tsx
+++ b/mobile-app/src/components/cellar-sections.tsx
@@ -1,21 +1,20 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { ActivityIndicator, FlatList, Image, Pressable, RefreshControl, StyleSheet, Text, TextInput, View } from "react-native";
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, StyleSheet, Text, TextInput, View } from "react-native";
 
-import { buildWsetSummary, type WsetTastingData } from "../lib/wset-data";
 import type { StorageSpaceRow } from "../types/storage-space";
 import type { SessionParticipant, TastingSessionRow } from "../types/tasting-session";
 import type { WineHistoryRecord } from "../types/wine-history";
-import type { WineRecord } from "../types/wine";
 import type { CellarSection } from "../types/cellar";
 import { Expandable, InsightCard, LoadingInline, PanelHeader } from "./form-controls";
 import { buildHistoryStats } from "../lib/cellar-helpers";
 import { fetchSessionWines, fetchSessionTastings, fetchSessionParticipants } from "../lib/session-actions";
-import { formatDateFull, formatDateISO } from "../lib/format-date";
+import { formatDateFull, formatDateShort } from "../lib/format-date";
 import { buildSessionResults } from "../lib/session-results";
 import { ResultsDashboard } from "./results-dashboard";
 import type { SessionWineRow, SessionTastingRow } from "../types/tasting-session";
 
-import { colors } from "../styles/theme";
+import { buildWsetSummary, type WsetTastingData } from "../lib/wset-data";
+import { colors, serifFont } from "../styles/theme";
 import type { styles as themeStyles } from "../styles/theme";
 import { WineGlassDoodle, TabIconCellar, TabIconAdd, TabIconTasting, TabIconDiscover, TabIconHistory } from "./doodles";
 type SharedStyles = typeof themeStyles;
@@ -98,34 +97,38 @@ export function HistoryPanel({
   const renderItem = useCallback(({ item }: { item: WineHistoryRecord }) => (
     <HistoryRow entry={item} styles={styles} onEdit={onEditEntry} />
   ), [styles, onEditEntry]);
+  const renderSeparator = useCallback(() => <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: colors.borderLight }} />, []);
 
   const sessionCount = endedSessions?.length ?? 0;
   const historyStats = useMemo(() => buildHistoryStats(historyEntries), [historyEntries]);
 
   const listHeader = useMemo(() => (
     <View style={{ gap: 14 }}>
-      <PanelHeader title="Historik" rightLabel="Profil" onRightPress={onOpenProfile} />
+      <PanelHeader rightLabel="Profil" onRightPress={onOpenProfile} />
+
+      <View>
+        <Text style={historyStyles.screenTitle}>Historik</Text>
+        <Text style={historyStyles.screenSub}>Flaskor du druckit och betygsatt</Text>
+      </View>
 
       {/* Sub-tabs */}
       <View style={historyStyles.tabRow}>
         <Pressable onPress={() => setTab("viner")} style={[historyStyles.tab, tab === "viner" && historyStyles.tabActive]}>
-          <Text style={[historyStyles.tabText, tab === "viner" && historyStyles.tabTextActive]}>Viner</Text>
+          <Text style={[historyStyles.tabText, tab === "viner" && historyStyles.tabTextActive]}>Viner ({historyEntries.length})</Text>
         </Pressable>
         <Pressable onPress={() => setTab("provningar")} style={[historyStyles.tab, tab === "provningar" && historyStyles.tabActive]}>
-          <Text style={[historyStyles.tabText, tab === "provningar" && historyStyles.tabTextActive]}>Provningar{sessionCount > 0 ? ` (${sessionCount})` : ""}</Text>
+          <Text style={[historyStyles.tabText, tab === "provningar" && historyStyles.tabTextActive]}>Provningar ({sessionCount})</Text>
         </Pressable>
       </View>
 
       {tab === "viner" && historyEntries.length > 0 ? (
         <>
-          <View style={styles.statsSummaryBar}>
-            <Text style={styles.statsSummaryText}>{historyStats.totalDrunk} flaskor druckna · {historyStats.totalTastings} tillfällen · snitt {historyStats.averageRating}/5</Text>
-          </View>
-          <View style={styles.statsGrid}>
-            <View style={styles.statsGridRow}>
-              <InsightCard label="Mest drucket land" value={historyStats.topCountry} />
-              <InsightCard label="Vanligaste typ" value={historyStats.topType} />
+          <View style={historyStyles.statsRow}>
+            <View style={historyStyles.statTan}>
+              <Text style={historyStyles.statTanValue} numberOfLines={1}>{historyStats.topCountry}</Text>
+              <Text style={historyStyles.statTanLabel}>mest drucket land</Text>
             </View>
+            <InsightCard label="Vanligast" value={historyStats.topType} />
           </View>
           <TextInput
             style={styles.input}
@@ -173,6 +176,7 @@ export function HistoryPanel({
       data={tab === "viner" ? filteredEntries : []}
       keyExtractor={(item) => item.id}
       renderItem={renderItem}
+      ItemSeparatorComponent={renderSeparator}
       ListHeaderComponent={listHeader}
       style={{ backgroundColor: colors.bg }}
       contentContainerStyle={[styles.panel, { flexGrow: 1, marginHorizontal: 20, marginTop: 20, maxWidth: 520, width: "100%", alignSelf: "center" as const }]}
@@ -243,63 +247,63 @@ function ExpandableSessionCard({ session, styles }: { session: TastingSessionRow
   );
 }
 
-const HistoryRow = React.memo(function HistoryRow({ entry, styles, onEdit }: {
+const HistoryRow = React.memo(function HistoryRow({ entry, onEdit }: {
   entry: WineHistoryRecord; styles: SharedStyles; onEdit?: (entry: WineHistoryRecord) => void;
 }) {
+  const meta = [entry.producer, entry.vintage, entry.grape].filter(Boolean).join(" · ");
   return (
-    <View style={styles.wineCard}>
-      <View style={styles.wineCardHeader}>
-        {entry.image_url ? (
-          <Image source={{ uri: entry.image_url }} style={styles.wineThumbnail} resizeMode="cover" accessibilityLabel={`Bild på ${entry.name}`} />
+    <Pressable
+      onPress={onEdit ? () => onEdit(entry) : undefined}
+      style={({ pressed }) => [historyStyles.histRow, pressed && onEdit ? { opacity: 0.65 } : null]}
+    >
+      <View style={historyStyles.histDateCol}>
+        <Text style={historyStyles.histDate}>{formatDateShort(entry.consumed_at)}</Text>
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={historyStyles.histName}>{entry.name}</Text>
+        {meta ? <Text style={historyStyles.histMeta}>{meta}</Text> : null}
+        {entry.tasting_notes ? (
+          <Text style={historyStyles.histNote} numberOfLines={2}>{`"${entry.tasting_notes}"`}</Text>
         ) : null}
-        <View style={styles.flex}>
-          <Text style={styles.wineType}>{entry.type || "Historik"}</Text>
-          <Text style={styles.wineName}>{entry.name}</Text>
-          <Text style={styles.wineMeta}>
-            {[entry.producer, entry.vintage, entry.grape, [entry.country, entry.region].filter(Boolean).join(", ")]
-              .filter(Boolean)
-              .join(" • ")}
+        {entry.tasting_data ? (
+          <Text style={historyStyles.histWset} numberOfLines={1}>
+            <Text style={historyStyles.histWsetLabel}>WSET</Text>
+            {"  "}{buildWsetSummary(entry.tasting_data as WsetTastingData)}
           </Text>
-        </View>
-        {entry.rating ? (
-          <View style={styles.ratingBadge}>
-            <Text style={styles.ratingBadgeText}>{"★".repeat(entry.rating)}{"☆".repeat(5 - entry.rating)}</Text>
-          </View>
         ) : null}
       </View>
-      <Text style={historyStyles.consumedText}>
-        Dracks {formatDateISO(entry.consumed_at)} · {entry.quantity_consumed} flaska
-        {entry.quantity_consumed > 1 ? "r" : ""}
-      </Text>
-      {entry.tasting_notes ? <Text style={styles.notesText}>{entry.tasting_notes}</Text> : null}
-      {entry.tasting_data ? (
-        <View style={historyStyles.wsetSection}>
-          <Text style={historyStyles.wsetLabel}>WSET Tasting</Text>
-          <Text style={styles.notesText}>{buildWsetSummary(entry.tasting_data as WsetTastingData)}</Text>
-        </View>
+      {entry.rating ? (
+        <Text style={historyStyles.histRating}>
+          {"★".repeat(entry.rating)}{"☆".repeat(5 - entry.rating)}
+        </Text>
       ) : null}
-      {onEdit ? (
-        <Pressable onPress={() => onEdit(entry)} style={({ pressed }) => [historyStyles.editButton, pressed && { opacity: 0.6 }]}>
-          <Text style={historyStyles.editButtonText}>Redigera</Text>
-        </Pressable>
-      ) : null}
-    </View>
+    </Pressable>
   );
 });
 
 const historyStyles = StyleSheet.create({
-  tabRow: { flexDirection: "row", gap: 0, backgroundColor: colors.surfaceAlt, borderRadius: 12, padding: 3 },
+  screenTitle: { fontFamily: serifFont, color: colors.text, fontSize: 32, fontWeight: "700", lineHeight: 34 },
+  screenSub: { color: colors.textSecondary, fontSize: 13, marginTop: 4 },
+  tabRow: { flexDirection: "row", backgroundColor: colors.surfaceAlt, borderRadius: 12, padding: 3 },
   tab: { flex: 1, paddingVertical: 8, alignItems: "center", borderRadius: 10 },
   tabActive: { backgroundColor: colors.accent },
   tabText: { color: colors.accent, fontSize: 13, fontWeight: "700" },
   tabTextActive: { color: colors.textLight },
-  editButton: { marginTop: 8, alignSelf: "flex-start", backgroundColor: colors.surfaceAlt, borderRadius: 999, paddingHorizontal: 12, paddingVertical: 6 },
-  editButtonText: { color: colors.accent, fontSize: 12, fontWeight: "700" },
+  statsRow: { flexDirection: "row", gap: 10 },
+  statTan: { flex: 1, backgroundColor: colors.surfaceAlt, borderRadius: 14, padding: 14, alignItems: "center", justifyContent: "center", gap: 2 },
+  statTanValue: { fontFamily: serifFont, color: colors.accent, fontSize: 22, fontWeight: "800", textAlign: "center" },
+  statTanLabel: { color: colors.textSecondary, fontSize: 11, fontWeight: "600" },
   sessionHeader: { flexDirection: "row", alignItems: "center", gap: 8 },
   sessionInfo: { flex: 1, gap: 4 },
   sessionResults: { marginTop: 12 },
   sessionList: { gap: 10 },
-  consumedText: { color: colors.textSecondary, fontSize: 13, fontWeight: "500" },
-  wsetSection: { marginTop: 6, paddingTop: 6, borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.border },
-  wsetLabel: { color: colors.textSecondary, fontWeight: "700", fontSize: 11, textTransform: "uppercase", letterSpacing: 0.6, marginBottom: 2 },
+  histRow: { flexDirection: "row", gap: 12, paddingVertical: 14 },
+  histDateCol: { width: 48, alignItems: "center" },
+  histDate: { fontFamily: serifFont, color: colors.accent, fontSize: 17, fontWeight: "500", fontStyle: "italic", lineHeight: 20, letterSpacing: 0.2 },
+  histName: { fontFamily: serifFont, color: colors.text, fontSize: 18, fontWeight: "700", lineHeight: 22 },
+  histMeta: { color: colors.textSecondary, fontSize: 12, marginTop: 2 },
+  histNote: { color: colors.text, fontSize: 13, marginTop: 4, fontStyle: "italic", lineHeight: 18 },
+  histRating: { color: colors.warm, fontSize: 13, letterSpacing: 1.5 },
+  histWset: { color: colors.textSecondary, fontSize: 12, marginTop: 4 },
+  histWsetLabel: { color: colors.accent, fontSize: 10, fontWeight: "700", letterSpacing: 1.4 },
 });

--- a/mobile-app/src/components/discover-tab.tsx
+++ b/mobile-app/src/components/discover-tab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { colors, styles as theme } from "../styles/theme";
+import { colors, serifFont, styles as theme } from "../styles/theme";
 import { getAvatarLetter, lookupByCellarCode, type ProfileRow } from "../lib/profile-actions";
 import { usePublicProfile } from "../hooks/usePublicProfile";
 import { PanelHeader } from "./form-controls";
@@ -44,11 +44,10 @@ export function DiscoverTab({ onOpenProfile }: Props) {
     setPeekProfile(profile);
   }
 
-  // Show inline public profile when a code is selected
   if (peekProfile && (publicProfile.profile || publicProfile.loading)) {
     return (
-      <View style={s.panel}>
-        <PanelHeader title="Upptäck" rightLabel="Profil" onRightPress={onOpenProfile} />
+      <View style={theme.panel}>
+        <PanelHeader rightLabel="Profil" onRightPress={onOpenProfile} />
         <PublicProfilePage
           profile={publicProfile.profile ?? peekProfile}
           summary={publicProfile.summary}
@@ -61,11 +60,13 @@ export function DiscoverTab({ onOpenProfile }: Props) {
   }
 
   return (
-    <View style={s.panel}>
-      <PanelHeader title="Upptäck" rightLabel="Profil" onRightPress={onOpenProfile} />
+    <View style={theme.panel}>
+      <PanelHeader rightLabel="Profil" onRightPress={onOpenProfile} />
 
-      <Text style={s.heading}>Titta in i en källare</Text>
-      <Text style={s.subtitle}>Skriv in en källarkod för att se någon annans vinsamling.</Text>
+      <View>
+        <Text style={s.screenTitle}>Upptäck</Text>
+        <Text style={s.screenSub}>Titta in i någon annans källare</Text>
+      </View>
 
       <View style={s.inputRow}>
         <TextInput
@@ -73,12 +74,12 @@ export function DiscoverTab({ onOpenProfile }: Props) {
           value={code}
           onChangeText={(t) => { setCode(t.toUpperCase().slice(0, 6)); setError(null); }}
           placeholder="KÄLLARKOD"
-          placeholderTextColor={colors.textSecondary}
+          placeholderTextColor={colors.textFaint}
           autoCapitalize="characters"
           maxLength={6}
         />
         <Pressable
-          style={[s.searchBtn, (!code.trim() || loading) && s.searchBtnDisabled]}
+          style={({ pressed }) => [s.searchBtn, (!code.trim() || loading) && s.searchBtnDisabled, pressed && { opacity: 0.85 }]}
           onPress={() => handleLookup(code)}
           disabled={!code.trim() || loading}
         >
@@ -88,30 +89,37 @@ export function DiscoverTab({ onOpenProfile }: Props) {
 
       {error ? <Text style={s.error}>{error}</Text> : null}
 
-      {publicProfile.loading && (
+      {publicProfile.loading ? (
         <View style={s.loadingRow}>
           <ActivityIndicator color={colors.accent} />
           <Text style={s.loadingText}>Laddar källare...</Text>
         </View>
-      )}
+      ) : null}
 
-      {recent.length > 0 && (
+      {recent.length > 0 ? (
         <>
           <SquigglyLine />
-          <Text style={s.sectionLabel}>Senast besökta</Text>
-          {recent.map((item) => (
-            <Pressable key={item.id} style={s.recentRow} onPress={() => handleLookup(item.cellar_code ?? "")}>
-              <View style={[s.avatar, { backgroundColor: item.avatar_color ?? colors.accent }]}>
-                <Text style={s.avatarLetter}>{getAvatarLetter(item.display_name)}</Text>
-              </View>
-              <View style={s.recentInfo}>
-                <Text style={s.recentName}>{item.display_name ?? "Okänd"}</Text>
-                <Text style={s.recentCode}>{item.cellar_code}</Text>
-              </View>
-            </Pressable>
-          ))}
+          <Text style={theme.eyebrow}>Senast besökta</Text>
+          <View style={{ gap: 0 }}>
+            {recent.map((item, i) => (
+              <Pressable
+                key={item.id}
+                style={({ pressed }) => [s.recentRow, i > 0 && s.recentRowBorder, pressed && { opacity: 0.65 }]}
+                onPress={() => handleLookup(item.cellar_code ?? "")}
+              >
+                <View style={[s.avatar, { backgroundColor: item.avatar_color ?? colors.accent }]}>
+                  <Text style={s.avatarLetter}>{getAvatarLetter(item.display_name)}</Text>
+                </View>
+                <View style={s.recentInfo}>
+                  <Text style={s.recentName}>{item.display_name ?? "Okänd"}</Text>
+                  <Text style={s.recentCode}>{item.cellar_code}</Text>
+                </View>
+                <Text style={s.recentChevron}>›</Text>
+              </Pressable>
+            ))}
+          </View>
         </>
-      )}
+      ) : null}
     </View>
   );
 }
@@ -133,35 +141,43 @@ async function saveRecent(profile: ProfileRow, existing: ProfileRow[]): Promise<
 }
 
 const s = StyleSheet.create({
-  panel: { gap: 12, flex: 1 },
-  heading: { color: colors.text, fontSize: 20, fontWeight: "700" },
-  subtitle: { color: colors.textSecondary, fontSize: 14, lineHeight: 20 },
-  inputRow: { flexDirection: "row", gap: 10 },
+  screenTitle: { fontFamily: serifFont, color: colors.text, fontSize: 32, fontWeight: "700", lineHeight: 34 },
+  screenSub: { color: colors.textSecondary, fontSize: 13, marginTop: 4 },
+  inputRow: { flexDirection: "row", gap: 10, alignItems: "stretch" },
   codeInput: {
-    flex: 1, borderRadius: 16, paddingHorizontal: 16, paddingVertical: 14,
-    backgroundColor: colors.surface, borderWidth: 1.5, borderColor: colors.border,
-    color: colors.text, fontSize: 20, fontWeight: "700", letterSpacing: 6, textAlign: "center",
+    flex: 1,
+    minWidth: 0,
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    color: colors.text,
+    fontSize: 18,
+    fontWeight: "700",
+    letterSpacing: 4,
+    textAlign: "center",
   },
   searchBtn: {
-    backgroundColor: colors.accent, borderRadius: 16,
-    paddingHorizontal: 20, justifyContent: "center", alignItems: "center", minWidth: 72,
+    backgroundColor: colors.accent,
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 60,
   },
   searchBtnDisabled: { opacity: 0.5 },
   searchBtnText: { color: "#FFF", fontWeight: "700", fontSize: 15 },
   error: { color: "#C85050", fontSize: 14, textAlign: "center" },
   loadingRow: { flexDirection: "row", justifyContent: "center", alignItems: "center", gap: 8, paddingVertical: 12 },
   loadingText: { color: colors.textSecondary, fontSize: 14 },
-  sectionLabel: {
-    color: colors.textSecondary, fontSize: 11, fontWeight: "700",
-    textTransform: "uppercase", letterSpacing: 0.6,
-  },
-  recentRow: {
-    flexDirection: "row", alignItems: "center", gap: 12,
-    paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: colors.borderLight,
-  },
+  recentRow: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 },
+  recentRowBorder: { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.borderLight },
   avatar: { width: 40, height: 40, borderRadius: 20, justifyContent: "center", alignItems: "center" },
   avatarLetter: { color: "#FFF", fontWeight: "700", fontSize: 17 },
   recentInfo: { flex: 1 },
-  recentName: { color: colors.text, fontWeight: "600", fontSize: 15 },
-  recentCode: { color: colors.textSecondary, fontSize: 12, letterSpacing: 1 },
+  recentName: { fontFamily: serifFont, color: colors.text, fontSize: 18, fontWeight: "700" },
+  recentCode: { color: colors.textSecondary, fontSize: 12, letterSpacing: 1.5, marginTop: 1 },
+  recentChevron: { color: colors.textSecondary, fontSize: 22, fontWeight: "400" },
 });

--- a/mobile-app/src/components/min-kallare-panel.tsx
+++ b/mobile-app/src/components/min-kallare-panel.tsx
@@ -110,8 +110,10 @@ export function MinKallarePanel(props: MinKallarePanelProps) {
   }, [props.highlightedWineId, sections]);
 
   const summaryText = useMemo(() => {
-    return `${stats.totalBottles} flaskor · snitt ${stats.averageVintage}`;
-  }, [stats.totalBottles, stats.averageVintage]);
+    const flaskor = `${stats.totalBottles} flask${stats.totalBottles === 1 ? "a" : "or"}`;
+    const labels = stats.totalLabels > 0 ? ` · ${stats.totalLabels} olika vin${stats.totalLabels === 1 ? "" : "er"}` : "";
+    return `${flaskor}${labels}`;
+  }, [stats.totalBottles, stats.totalLabels]);
 
   const renderSectionHeader = useCallback(({ section }: { section: WineSection }) => (
     <SectionHeader

--- a/mobile-app/src/components/tasting-tab.tsx
+++ b/mobile-app/src/components/tasting-tab.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-nati
 import { PanelHeader } from "./form-controls";
 import type { CreateSessionInput, TastingSessionRow } from "../types/tasting-session";
 import { CreateForm, JoinForm } from "./session-forms";
-import { colors, styles } from "../styles/theme";
+import { colors, serifFont, styles } from "../styles/theme";
 import { formatDateFull } from "../lib/format-date";
 
 type Props = {
@@ -25,6 +25,15 @@ function statusColor(status: TastingSessionRow["status"]): string {
   return status === "active" ? colors.accent : status === "setup" ? colors.textSecondary : colors.text;
 }
 
+function TitleBlock({ title, sub }: { title: string; sub: string }) {
+  return (
+    <View>
+      <Text style={local.title}>{title}</Text>
+      <Text style={local.sub}>{sub}</Text>
+    </View>
+  );
+}
+
 export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, onOpenSession, onOpenProfile, onFetchSessions }: Props) {
   useEffect(() => { onFetchSessions(); }, []);
   const [view, setView] = useState<"list" | "create" | "join">("list");
@@ -36,7 +45,8 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
   if (view === "create") {
     return (
       <View style={styles.panel}>
-        <PanelHeader title="Ny provning" rightLabel="Avbryt" onRightPress={() => setView("list")} />
+        <PanelHeader rightLabel="Avbryt" onRightPress={() => setView("list")} />
+        <TitleBlock title="Ny provning" sub="Bjud in vänner och bestäm format" />
         <CreateForm onCreate={async (input) => {
           const result = await onCreateSession(input);
           if (!result) { setError("Kunde inte skapa provning"); return; }
@@ -49,7 +59,8 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
   if (view === "join") {
     return (
       <View style={styles.panel}>
-        <PanelHeader title="Gå med i provning" rightLabel="Avbryt" onRightPress={() => setView("list")} />
+        <PanelHeader rightLabel="Avbryt" onRightPress={() => setView("list")} />
+        <TitleBlock title="Gå med" sub="Skriv in koden du fått" />
         <JoinForm onJoin={async (code) => {
           const result = await onJoinSession(code);
           if (!result) { setError("Kunde inte gå med — kontrollera koden"); return; }
@@ -61,7 +72,9 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
 
   return (
     <View style={styles.panel}>
-      <PanelHeader title="Provningar" rightLabel="Profil" onRightPress={onOpenProfile} />
+      <PanelHeader rightLabel="Profil" onRightPress={onOpenProfile} />
+      <TitleBlock title="Provning" sub="Blindprova med vänner" />
+
       {error ? <Text style={local.error}>{error}</Text> : null}
 
       <View style={local.actionRow}>
@@ -77,11 +90,11 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
 
       {activeSessions.length > 0 ? (
         <>
-          <Text style={local.sectionLabel}>Pågående</Text>
+          <Text style={styles.eyebrow}>Pågående</Text>
           {activeSessions.map((ses) => (
-            <Pressable key={ses.id} style={local.card} onPress={() => onOpenSession(ses)}>
+            <Pressable key={ses.id} style={({ pressed }) => [local.card, pressed && { opacity: 0.65 }]} onPress={() => onOpenSession(ses)}>
               <View style={local.cardHeader}>
-                <Text style={local.cardTitle}>{ses.title}</Text>
+                <Text style={local.cardTitle} numberOfLines={1}>{ses.title}</Text>
                 <Text style={[local.statusBadge, { color: statusColor(ses.status) }]}>{statusLabel(ses.status)}</Text>
               </View>
               <Text style={local.cardMeta}>{ses.mode === "blind" ? "Blind" : "Öppen"} · {ses.format.toUpperCase()}</Text>
@@ -90,14 +103,14 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
         </>
       ) : null}
 
-      <Text style={local.sectionLabel}>Avslutade</Text>
+      <Text style={styles.eyebrow}>Avslutade</Text>
       {endedSessions.length === 0 && !loading ? (
         <Text style={local.empty}>Inga avslutade provningar ännu.</Text>
       ) : null}
       {endedSessions.map((ses) => (
-        <Pressable key={ses.id} style={local.card} onPress={() => onOpenSession(ses)}>
+        <Pressable key={ses.id} style={({ pressed }) => [local.card, pressed && { opacity: 0.65 }]} onPress={() => onOpenSession(ses)}>
           <View style={local.cardHeader}>
-            <Text style={local.cardTitle}>{ses.title}</Text>
+            <Text style={local.cardTitle} numberOfLines={1}>{ses.title}</Text>
             <Text style={local.cardDate}>{formatDateFull(ses.created_at)}</Text>
           </View>
           <Text style={local.cardMeta}>{ses.mode === "blind" ? "Blind" : "Öppen"} · {ses.format.toUpperCase()}</Text>
@@ -108,14 +121,15 @@ export function TastingTab({ sessions, loading, onCreateSession, onJoinSession, 
 }
 
 const local = StyleSheet.create({
-  actionRow: { flexDirection: "row", gap: 10, marginBottom: 16 },
-  sectionLabel: { color: colors.text, fontSize: 14, fontWeight: "700", marginTop: 16, marginBottom: 8, textTransform: "uppercase", letterSpacing: 0.5 },
-  card: { backgroundColor: colors.textLight, borderRadius: 18, padding: 14, gap: 4, borderWidth: 1, borderColor: colors.surfaceAlt, marginBottom: 8 },
-  cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
-  cardTitle: { color: colors.text, fontSize: 16, fontWeight: "700", flex: 1 },
+  title: { fontFamily: serifFont, color: colors.text, fontSize: 32, fontWeight: "700", lineHeight: 34 },
+  sub: { color: colors.textSecondary, fontSize: 13, marginTop: 4 },
+  actionRow: { flexDirection: "row", gap: 10, marginTop: 4 },
+  card: { backgroundColor: colors.surface, borderRadius: 18, padding: 14, gap: 6, borderWidth: 1, borderColor: colors.border },
+  cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 8 },
+  cardTitle: { fontFamily: serifFont, color: colors.text, fontSize: 18, fontWeight: "700", flex: 1 },
   cardMeta: { color: colors.textSecondary, fontSize: 13 },
-  cardDate: { color: colors.textSecondary, fontSize: 12 },
-  statusBadge: { fontSize: 12, fontWeight: "600" },
+  cardDate: { color: colors.textSecondary, fontSize: 12, fontStyle: "italic" },
+  statusBadge: { fontSize: 11, fontWeight: "700", letterSpacing: 1.2, textTransform: "uppercase" },
   empty: { color: colors.textSecondary, fontSize: 13, fontStyle: "italic" },
-  error: { color: colors.accent, fontSize: 13, marginBottom: 8 },
+  error: { color: colors.accent, fontSize: 13 },
 });

--- a/mobile-app/src/styles/theme.ts
+++ b/mobile-app/src/styles/theme.ts
@@ -2,7 +2,7 @@ import { Platform, StyleSheet } from "react-native";
 import { colors, serifFont, handFont } from "./tokens";
 
 // Re-export tokens for backward compatibility
-export { colors, handFont };
+export { colors, handFont, serifFont };
 
 export const styles = StyleSheet.create({
   flex: { flex: 1 },

--- a/mobile-app/src/styles/tokens.ts
+++ b/mobile-app/src/styles/tokens.ts
@@ -24,6 +24,7 @@ export const colors = {
   text: "#2A2A2A",
   textSecondary: "#666666",
   textLight: "#FDFAF6",
+  textFaint: "#8F8178",
   border: "#E0D8CE",
   borderLight: "#F0EBE3",
   black: "#1A1A1A",

--- a/mobile-app/src/styles/tokens.ts
+++ b/mobile-app/src/styles/tokens.ts
@@ -8,7 +8,7 @@ export const serifFont = Platform.select({
 });
 
 export const handFont = Platform.select({
-  web: '"Caveat", cursive',
+  web: '"Caveat", Georgia, serif',
   ios: "Noteworthy-Bold",
   default: "serif",
 });


### PR DESCRIPTION
## Summary
Five-tab visual refresh based on the Vinkällaren Design System handoff bundle. Functionality is unchanged on every tab — this PR lifts the visual vocabulary (title block, tokens, panel shadow) to be consistent across Min källare, Lägg till, Provning, Upptäck and Historik.

## Commits
- `ea2cab7` — **Historik**: new HistRow (italic-serif date, italic quote note, terracotta stars, row taps to edit), stats row → 2-tile mockup layout, WSET shown as subtle one-line eyebrow when present. `handFont` fallback on web switched from `cursive` to `Georgia, serif` so Caveat never falls back to Comic Sans on Windows.
- `8c3b655` — **Upptäck**: wraps content in design-system panel with stamp shadow + serif title block, adds `textFaint` token, fixes the Sök button that was overflowing the panel's rounded right corner.
- `70dd2db` — **Lägg till**: serif title block ("Lägg till vin" / "Fyll i själv, eller skanna etiketten") above the existing form, no other changes.
- `ef84d3d` — **Provning**: serif title + subtitle on the list, Ny provning and Gå med views; replaces ad-hoc section labels with the shared `eyebrow` style; session cards get serif title + italic date + pill status.
- `0e6d976` — **Min källare**: stats-pill replaced by serif title + "N flaskor · N olika viner" subtitle, with a "Visa statistik" accent link that still expands the detailed insight grid.

## Test plan
- [ ] Run `npm run web` in `mobile-app/` and walk through the five tabs. Expect consistent serif title + subtitle at the top of each panel, followed by the existing content.
- [ ] On Historik, confirm the date reads as italic serif (not Comic Sans), the star rating stays terracotta, and tapping a row opens the edit modal.
- [ ] On Upptäck, confirm the Sök button sits visibly inside the panel at mobile width (420px).
- [ ] On Min källare, confirm "Visa statistik" still expands the 2×2 InsightCard grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)